### PR TITLE
Try out unit-style thunks

### DIFF
--- a/examples/LogRunnerExample.elm
+++ b/examples/LogRunnerExample.elm
@@ -20,7 +20,7 @@ main =
     Html.App.beginnerProgram
         { model = ()
         , update = \_ _ -> ()
-        , view = \_ -> Html.text "Check the console for useful output!"
+        , view = \() -> Html.text "Check the console for useful output!"
         }
         |> Test.Runner.Log.run testOxfordify
 
@@ -37,29 +37,29 @@ testOxfordify =
     describe "oxfordify"
         [ describe "given an empty sentence"
             [ test "returns an empty string" <|
-                \_ ->
+                \() ->
                     oxfordify "This sentence is empty" "." []
                         |> Assert.equal ""
             ]
         , describe "given a sentence with one item"
             [ test "still contains one item" <|
-                \_ ->
+                \() ->
                     oxfordify "This sentence contains " "." [ "one item" ]
                         |> Assert.equal "This sentence contains one item."
             ]
         , describe "given a sentence with multiple items"
             [ test "returns an oxford-style sentence" <|
-                \_ ->
+                \() ->
                     oxfordify "This sentence contains " "." [ "one item", "two item" ]
                         |> Assert.equal "This sentence contains one item and two item."
             , test "returns an oxford-style sentence" <|
-                \_ ->
+                \() ->
                     oxfordify "This sentence contains " "." [ "one item", "two item", "three item" ]
                         |> Assert.equal "This sentence contains one item, two item, and three item."
             ]
         , describe "a long failure message"
             [ test "long failure!" <|
-                \_ ->
+                \() ->
                     Assert.equal "html, body {\nwidth: 100%;\nheight: 100%;\nbox-sizing: border-box;\npadding: 0;\nmargin: 0;\n}\n\nbody {\nmin-width: 1280px;\noverflow-x: auto;\n}\n\nbody > div {\nwidth: 100%;\nheight: 100%;\n}\n\n.dreamwriterHidden {\ndisplay: none !important;\n}\n\n#dreamwriterPage {\nwidth: 100%;\nheight: 100%;\nbox-sizing: border-box;\nmargin: 0;\npadding: 8px;\nbackground-color: rgb(100, 90, 128);\ncolor: rgb(40, 35, 76);\n}"
                         "html, body {\nwidth: 100%;\nheight: 100%;\nbox-sizing: border-box;\npadding: 0;\nmargin: 0;\n}\n\nbody {\nmin-width: 1280px;\noverflow-x: auto;\n}\n\nbody > div {\nwidth: 100%;\nheight: 100%;\n}\n\n.dreamwriterHidden {\ndisplay: none !important;\n}\n\n#Page {\nwidth: 100%;\nheight: 100%;\nbox-sizing: border-box;\nmargin: 0;\npadding: 8px;\nbackground-color: rgb(100, 90, 128);\ncolor: rgb(40, 35, 76);\n}"
             ]

--- a/src/Assert.elm
+++ b/src/Assert.elm
@@ -257,7 +257,7 @@ false message bool =
 
 
     test "Json.Decode.int can decode the number 42." <|
-        \_ ->
+        \() ->
             case decodeString int "42" of
                 Ok _ ->
                     Assert.pass
@@ -278,7 +278,7 @@ pass =
 
 
     test "Json.Decode.int can decode the number 42." <|
-        \_ ->
+        \() ->
             case decodeString int "42" of
                 Ok _ ->
                     Assert.pass

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -51,7 +51,7 @@ batch =
     describe "List"
         [ describe "reverse"
             [ test "has no effect on an empty list" <|
-                \_ ->
+                \() ->
                     List.reverse []
                         |> Assert.equal []
             , fuzz int "has no effect on a one-item list" <|
@@ -74,7 +74,7 @@ describe desc =
 
 
     test "the empty list has 0 length" <|
-        \_ ->
+        \() ->
             List.length []
                 |> Assert.equal 0
 -}

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -53,7 +53,7 @@ fromTest : Int -> Random.Seed -> Test -> Runner
 fromTest runs seed test =
     case test of
         Test.Test.Test run ->
-            Thunk (\_ -> run seed runs)
+            Thunk (\() -> run seed runs)
                 |> Runnable
 
         Test.Test.Labeled label subTest ->
@@ -76,7 +76,7 @@ distributeSeeds runs test ( startingSeed, runners ) =
                 ( seed, nextSeed ) =
                     Random.step Random.independentSeed startingSeed
             in
-                ( nextSeed, runners ++ [ Runnable (Thunk (\_ -> run seed runs)) ] )
+                ( nextSeed, runners ++ [ Runnable (Thunk (\() -> run seed runs)) ] )
 
         Test.Test.Labeled label subTest ->
             let


### PR DESCRIPTION
@avh4 suggested writing `\() ->` instead of `\_ ->` for unit tests.

Either will compile, but there are benefits and drawbacks to being explicit.

**Benefits:**
- Makes it clear that the argument is never useful
- If you make a copy/paste error like writing `fuzz string` instead of `test`, this will give you a compile error, whereas `\_ ->` will ignore the `string` and let you waste CPU cycles running identical tests over and over, and as a reward, if it fails, it'll multiply the failures in a confusing way.

**Drawbacks:**
- It's one character longer
- Looks different than the familiar hockey stick of `\_ ->`

Thoughts @mgold @evancz @eeue56 @scottcorgan et al?
